### PR TITLE
setup 시 twitter template0이 설치 되지 않는 문제를 해결합니다.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
    install_requires=["Jpype1>=0.6.1", "konlpy>=0.4.4"],
    keywords = ['KoNLPy wrapping customization'],
    packages=find_packages(),
-   package_data={'ckonlpy':['data/*/*.txt', 'data/*/*/*.txt']}
+   package_data={'ckonlpy':['data/*/*.txt', 'data/*/*/*.txt', 'data/templates/*']}
 )


### PR DESCRIPTION
* PyPI에는 egg_info에 data/templates에 대한 내용이 하드코딩으로 기재되어있어서 정상작동 하지만 setup.py에  data/templates 에 대한 내용이 없어서 직접 설치할 경우에는 설치되지 않습니다.
* 이 문제를 해결합니다.